### PR TITLE
Update VN Map branding to my repo

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -65,4 +65,4 @@ excluded_tools: []
 # (contrary to the memories, which are loaded on demand).
 initial_prompt: ""
 
-project_name: "leaflet-nextjs-ts-starter"
+project_name: "vn-map"

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
-VN Map - Interactive Vietnam Province Map
+VN Map - Searchable Map of Vietnam Provinces and Wards
 ===============
 
-An interactive Vietnam map application built with [Next.js](https://nextjs.org/) and [Leaflet React](https://react-leaflet.js.org/). Features province search, detailed statistics, and beautiful visualizations. Template enhanced by [Tailwind CSS](https://tailwindcss.com/) and [Lucide icons](https://lucide.dev/). ✨
-Built with [TypeScript](https://www.typescriptlang.org/) 👐.
+VN Map helps you search and display the latest positions of provinces and wards after Vietnam's administrative reform mergers. Built with [Next.js](https://nextjs.org/) and [React Leaflet](https://react-leaflet.js.org/) and styled by [Tailwind CSS](https://tailwindcss.com/) with [Lucide icons](https://lucide.dev/). ✨ Built with [TypeScript](https://www.typescriptlang.org/) 👐.
 
-Packed with Vietnam-specific components including province search, GeoJSON visualization, and administrative data display for Vietnamese mapping projects.
+VN Map provides province search, GeoJSON visualization and up‑to‑date administrative information to help you explore the new province and ward structure across Vietnam.
 
 ### Table of Contents
 1. [Features](#features)
@@ -37,7 +36,7 @@ Packed with Vietnam-specific components including province search, GeoJSON visua
 
 #### <a id="breaking-changes"></a> 💣 Breaking Changes introduced > v0.1.1
 
-In Version v0.1.2, I changed the path aliases to be more consistent with the ES standards from `@alias` to `#alias`. If pulling the template from v0.1.1 you have to change the import paths in your components and pages.
+In Version v0.1.2, I changed the path aliases to be more consistent with the ES standards from `@alias` to `#alias`. If upgrading from v0.1.1 you have to change the import paths in your components and pages.
 
 ```diff
 - import { SomeComponent } from '@components/useMap'
@@ -48,7 +47,7 @@ In Version v0.1.2, I changed the path aliases to be more consistent with the ES 
 
 Create new Github repo with vercel and deploy it within minutes. Could not be easier as hitting some buttons. Shipping of private repos is possible.
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fyour-username%2Fvn-map)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fcaocuong2404%2Fvn-map)
 
 Later: Check out your repo locally and run ```npm install``` or ```yarn``` in root
 
@@ -57,7 +56,7 @@ Follow Instructions for [Starting Up](#start-up)
 #### <a id="manual-install"></a> ⚙️ Manual install
 
 ```bash
-git clone https://github.com/your-username/vn-map
+git clone https://github.com/caocuong2404/vn-map
 # then
 npm install
 # or  

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "next-leaflet-starter-typescript",
+  "name": "vn-map",
   "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -3,13 +3,13 @@
   "homepage": "https://vn-map.vercel.app",
   "version": "0.1.3",
   "license": "MIT",
-  "author": "Richard Unterberg <https://github.com/richard-unterberg>",
+  "author": "Cuong C. Nguyen <https://github.com/caocuong2404>",
   "repository": {
     "type": "git",
-    "url": "https://github.com/richard-unterberg/next-leaflet-starter-typescript/"
+    "url": "https://github.com/caocuong2404/vn-map"
   },
   "bugs": {
-    "url": "https://github.com/richard-unterberg/next-leaflet-starter-typescript/issues"
+    "url": "https://github.com/caocuong2404/vn-map/issues"
   },
   "scripts": {
     "dev": "next dev",

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -7,16 +7,11 @@ import Link from 'next/link'
 const Home = () => (
   <div className="container mx-auto max-w-2xl p-3 max-md:max-w-none">
     <Head>
-      <title>Jumpstart your new leaflet mapping Project with next.js and typescript 🤩</title>
-      <meta
-        property="og:title"
-        content="Jumpstart your new leaflet mapping Project with next.js and typescript 🤩"
-        key="title"
-      />
+      <title>VN Map - Provinces and Wards after Reform</title>
+      <meta property="og:title" content="VN Map - Provinces and Wards after Reform" key="title" />
       <meta
         name="description"
-        content="next-leaflet-starter-typescript is an extensible next.js starter template for the leaflet-maps-react plugin. Written in typescript,
-      visually enhanced by tailwind and lucide-react icons."
+        content="Search and display positions of provinces and wards after Vietnam's reform mergers."
       />
     </Head>
     <header className="items-top mt-10 gap-4 md:flex">
@@ -24,40 +19,37 @@ const Home = () => (
         <Leaf size={AppConfig.ui.bigIconSize} className="mt-2" />
       </span>
       <div>
-        <h2 className="text-4xl font-bold ">Next.js starter for leaflet-react</h2>
-        <h3 className="mb-16 text-3xl">written in Typescript</h3>
+        <h2 className="text-4xl font-bold ">VN Map - Explore Reformed Vietnam</h2>
+        <h3 className="mb-16 text-3xl">search provinces and wards with ease</h3>
       </div>
     </header>
     <section>
       <p className="mb-2">
-        <span>An extensible </span>
+        <span>An interactive map built with </span>
         <Link className="text-primary" target="_blank" href="https://nextjs.org/">
-          next.js
+          Next.js
         </Link>
-        <span> starter for the </span>
+        <span> and </span>
         <Link className="text-primary" target="_blank" href="https://react-leaflet.js.org/">
-          leaflet-react
+          React Leaflet
         </Link>
-        <span> plugin. Written in </span>
+        <span>. Written in </span>
         <Link className="text-primary" target="_blank" href="https://www.typescriptlang.org/">
-          typescript
+          TypeScript
         </Link>
-        <span>, visually enhanced by </span>
+        <span> and styled with </span>
         <Link className="text-primary" target="_blank" href="https://tailwindcss.com/">
-          tailwind
+          Tailwind
         </Link>
         <span> and </span>
         <Link className="text-primary" target="_blank" href="https://lucide.dev/">
-          lucide icons
+          Lucide icons
         </Link>
         <span>. ✨</span>
       </p>
       <p className="my-3">
         <span> 🤝 Feel free to contribute on </span>
-        <Link
-          href="https://github.com/richard-unterberg/typescript-next-leaflet-starter"
-          className="text-primary"
-        >
+        <Link href="https://github.com/caocuong2404/vn-map" className="text-primary">
           Github
         </Link>
       </p>
@@ -71,11 +63,8 @@ const Home = () => (
     <footer className="mt-16 flex justify-between rounded bg-light p-3 text-sm">
       <div>
         2023, some rights reserved <br />
-        <Link
-          href="https://github.com/richard-unterberg/typescript-next-leaflet-starter"
-          className="text-primary"
-        >
-          typescript-next-leaflet-starter
+        <Link href="https://github.com/caocuong2404/vn-map" className="text-primary">
+          VN Map
         </Link>
       </div>
       <div className="text-primary">

--- a/src/pages/map/index.tsx
+++ b/src/pages/map/index.tsx
@@ -4,16 +4,11 @@ import Head from 'next/head'
 const MapPage = () => (
   <div>
     <Head>
-      <title>Map Example | Jumpstart your new leaflet mapping Project with next.js and typescript 🤩</title>
-      <meta
-        property="og:title"
-        content="Map Example | Jumpstart your new leaflet mapping Project with next.js and typescript 🤩"
-        key="title"
-      />
+      <title>VN Map</title>
+      <meta property="og:title" content="VN Map" key="title" />
       <meta
         name="description"
-        content="next-leaflet-starter-typescript is an extensible next.js starter template for the leaflet-maps-react plugin. Written in typescript,
-      visually enhanced by tailwind and lucide-react icons."
+        content="Search and display positions of provinces and wards after Vietnam's reform mergers."
       />
     </Head>
     <Map />


### PR DESCRIPTION
## Summary
- describe VN Map as a post-merger province and ward locator
- remove old template mention in breaking changes note
- point links to `caocuong2404/vn-map` and set author
- update metadata on the sample pages

## Testing
- `npm run lint` *(warnings only)*

------
https://chatgpt.com/codex/tasks/task_e_688c31cd02f8832daf36198942679f2c